### PR TITLE
refactor: remove console log from history handler and clean up query …

### DIFF
--- a/function/history/handler.ts
+++ b/function/history/handler.ts
@@ -22,7 +22,5 @@ export const handler = async (event: APIGatewayEvent, context: Context): Promise
     res = await router[path](event, context);
   }
 
-  console.log(res);
-
   return res;
 }

--- a/function/history/history.ts
+++ b/function/history/history.ts
@@ -65,9 +65,11 @@ async function handleGet({
     `;
 
     const queryParams: (string | number)[] = [session.user_id];
+
     if (prayer_history_id !== undefined) {
       queryParams.push(prayer_history_id);
     }
+
     if (historyRange !== undefined) {
       queryParams.push(historyRange);
     }


### PR DESCRIPTION
history service에서 불필요하게 찍히는 console.log를 삭제합니다.