### PR TITLE
Faet: app notice handler 추가

### DIFF
--- a/function/appInfo/appNotice.ts
+++ b/function/appInfo/appNotice.ts
@@ -1,0 +1,80 @@
+import { APIGatewayEvent, APIGatewayProxyResult, Context } from "aws-lambda";
+
+import { promisePool } from 'customMysql';
+import { AppInfoType } from "../dataType";
+
+async function handleGet(): Promise<APIGatewayProxyResult> {
+
+  try {
+
+    const [rows] = await promisePool.query(`
+    SELECT * FROM app_notice
+    `, []) as [AppInfoType[], unknown];
+
+    if (rows.length === 0) {
+      return {
+        statusCode: 404,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+        },
+        body: JSON.stringify({ message: "not found" }),
+      };
+    }
+
+    return {
+      statusCode: 200,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: JSON.stringify({
+        ...rows[0]
+      }),
+    }
+
+  } catch (e) {
+    console.error(e);
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: JSON.stringify({ message: "internal server error" }),
+    };
+  }
+}
+
+export const appNoticeHandler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {
+  try {
+    const HttpMethod = event.requestContext.httpMethod;
+
+    let response: any = {};
+
+    switch (HttpMethod.toLowerCase()) {
+      case "get":
+        response = await handleGet();
+        break;
+      default:
+        response = {
+          statusCode: 405,
+          headers: {
+            "Access-Control-Allow-Origin": "*",
+          },
+          body: JSON.stringify({ message: "Method Not Allowed" }),
+        };
+        break;
+    }
+
+    return response;
+
+  } catch (e) {
+    console.error(e);
+    return {
+      statusCode: 500,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+      body: JSON.stringify({ message: "internal server error" }),
+    };
+
+  }
+}

--- a/function/appInfo/handler.ts
+++ b/function/appInfo/handler.ts
@@ -1,8 +1,10 @@
 import { Context, APIGatewayEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { appInfoHandler } from './appInfo';
+import { appNoticeHandler } from './appNotice';
 
 const router: { [key: string]: (event: APIGatewayEvent, context: Context) => Promise<APIGatewayProxyResult> } = {
-  "/appInfo": appInfoHandler
+  "/appInfo": appInfoHandler,
+  "/appNotice": appNoticeHandler
 }
 
 export const handler = async (event: APIGatewayEvent, context: Context): Promise<APIGatewayProxyResult> => {

--- a/template.yml
+++ b/template.yml
@@ -403,6 +403,12 @@ Resources:
             Path: /appInfo
             Method: GET
             RestApiId: !Ref ourprayer
+        ourprayerGETappNotice:
+          Type: Api
+          Properties:
+            Path: /appNotice
+            Method: GET
+            RestApiId: !Ref ourprayer
     # https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-using-build-typescript.html
     Metadata:
       BuildMethod: esbuild
@@ -601,6 +607,13 @@ Resources:
                 uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${lecture.Arn}/invocations
               responses: {}
           /appInfo:
+            get:
+              x-amazon-apigateway-integration:
+                httpMethod: POST
+                type: aws_proxy
+                uri: !Sub arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${appInfo.Arn}/invocations
+              responses: {}
+          /appNotice:
             get:
               x-amazon-apigateway-integration:
                 httpMethod: POST


### PR DESCRIPTION
## Description
  - appNotice 조회용 Lambda 핸들러를 추가하고, /appNotice GET 라우트를 handler와 API Gateway(SAM 템플릿)에 연결해 앱 공지 조회 엔드포인트를 제공함.
  - app_notice 테이블에서 최신 공지 데이터를 읽어 200/404/500 응답을 반환하도록 구현함.

## Notice:
  - 신규 엔드포인트는 기존 appInfo Lambda에 라우팅되며, /appInfo와 동일한 API Gateway 설정을 공유함.
  - app_notice 테이블에 데이터가 없으면 404를 반환하도록 설계됨.
  - template.yml에 /appNotice 경로와 API Gateway 통합이 추가됨.